### PR TITLE
Remove FlatCompat from eslint.config.js

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,27 +1,13 @@
-import path from 'node:path';
-import { fileURLToPath } from 'node:url';
-
-const __filename = fileURLToPath(import.meta.url); // eslint-disable-line no-underscore-dangle
-const __dirname = path.dirname(__filename); // eslint-disable-line no-underscore-dangle
-
-import { FlatCompat } from '@eslint/eslintrc';
 import js from '@eslint/js';
 import mochaPlugin from 'eslint-plugin-mocha';
 import reactPlugin from 'eslint-plugin-react';
 import globals from 'globals';
 
-const compat = new FlatCompat({
-	baseDirectory: __dirname,
-	recommendedConfig: js.configs.recommended,
-	allConfig: js.configs.all
-});
-
 export default [
-	...compat.extends(
-		'eslint:recommended',
-		'plugin:react/recommended'
-	),
+	js.configs.recommended,
 	mochaPlugin.configs.recommended,
+	reactPlugin.configs.flat.recommended,
+	reactPlugin.configs.flat['jsx-runtime'],
 	{
 		ignores: [
 			'built/*',
@@ -83,8 +69,7 @@ export default [
 			react: reactPlugin
 		},
 		rules: {
-			'react/prop-types': 'off',
-			'react/react-in-jsx-scope': 'off'
+			'react/prop-types': 'off'
 		}
 	},
 	{


### PR DESCRIPTION
This PR updates the `eslint.config.js` by using ESLint v9 flat configs instead of an old-style “extends” string.

It also applies the below replacement because they do the same thing (disables the “React must be in scope” rules for React projects):
```diff
+ reactPlugin.configs.flat['jsx-runtime'],
```

```diff
- 'react/react-in-jsx-scope': 'off'
```