### PR TITLE
Remove ESLint rules in js.configs.recommended

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -38,11 +38,8 @@ export default [
 			'no-caller': 'error',
 			'no-console': 'error',
 			'no-extend-native': 'error',
-			'no-irregular-whitespace': 'error',
 			'no-loop-func': 'error',
-			'no-undef': 'error',
 			'no-underscore-dangle': 'error',
-			'no-unused-vars': 'error',
 			'no-var': 'error',
 			'one-var': ['error', 'never'],
 			strict: ['error', 'global']


### PR DESCRIPTION
This PR removes ESLint rules that are already present from `js.configs.recommended`.

ChatGPT:

> Second, remove rules you’re already getting from `js.configs.recommended`. ESLint’s `js/recommended` turns on all rules marked as recommended, and that includes `no-undef`, `no-unused-vars`, and `no-irregular-whitespace`, so keeping them again in your own `rules` block is redundant.
>
> So I’d also remove:
>
> ```js
> 'no-undef'
> 'no-unused-vars'
> 'no-irregular-whitespace'
> ```