### PR TITLE
Fix autocomplete loading container spinner animation

### DIFF
--- a/src/client/scripts/autocomplete.js
+++ b/src/client/scripts/autocomplete.js
@@ -31,7 +31,9 @@ function createLoadingContainer() {
 }
 
 function showLoadingPane(instance) {
-	instance.container.appendChild(instance.loadingContainer);
+	if (!instance.container.contains(instance.loadingContainer)) {
+		instance.container.appendChild(instance.loadingContainer);
+	}
 
 	const menu = instance.container.querySelector('.autocomplete__menu');
 


### PR DESCRIPTION
This PR fixes an issue with the loading container spinner animation.

### Before

Upon every keystroke, the animation restarts, which is distracting.

https://github.com/user-attachments/assets/efdf56ff-df06-4a85-8c11-a94ae62541c7

### After

Despite keystrokes, the animation continues uninterrupted.

https://github.com/user-attachments/assets/12e1ac97-7b2d-4c8b-95b1-08e1f9395c9e