### PR TITLE
Reset clickable area of header home page link

### DIFF
--- a/src/client/stylesheets/header.css
+++ b/src/client/stylesheets/header.css
@@ -11,7 +11,8 @@
 }
 
 .header__home-link {
-	display: flex;
+	display: inline-flex;
+	vertical-align: bottom;
 	align-items: center;
 	gap: 10px;
 	line-height: 1;


### PR DESCRIPTION
The changes in this PR https://github.com/andygout/dramatis-ssr/pull/329 unintentionally increased the clickable area of the header home page link.

This PR reverts it to its previous state.

### Before
<img width="1004" height="129" alt="home-link-before" src="https://github.com/user-attachments/assets/2974e402-8ac9-4a00-a3cc-e850c9424b89" />

### After
<img width="1004" height="129" alt="home-link-after" src="https://github.com/user-attachments/assets/d6499644-d34f-4c14-bd79-e5e1856c7248" />